### PR TITLE
fix: terraform.tfvars.templateのTiDBデプロイ先のインスタンスの数を2個に修正

### DIFF
--- a/tidb-cluster/terraform/terraform.tfvars.template
+++ b/tidb-cluster/terraform/terraform.tfvars.template
@@ -14,7 +14,7 @@ server_local_password = "dummy_password"
 
 ## TiDB クラスターの設定
 # TiDBサーバの個数
-num_tidb_servers = 1
+num_tidb_servers = 2
 # TiKV & PD サーバの個数
 num_tikv_servers = 3
 # VPCルーターのIPアドレス


### PR DESCRIPTION
#  課題
Ch8「TiDBクラスターを作って運用しよう」のp349にて`ansible cluster -i inventory.ini -m ping`を実行したところTiDBの２台目をデプロイするためのインスタンスが立ち上げっておらず、pingに失敗しました。


```terminal
$ ansible cluster -i inventory.ini -m ping
...
192.168.100.12 | UNREACHABLE! => {
    "changed": false,
    "msg": "Failed to connect to the host via ssh: ssh: connect to host 192.168.100.12 port 22: No route to host",
    "unreachable": true
}
```

# 修正内容

terraform.tfvarsのnum_tidb_servresを確認したところ1になっていたので2に修正してterraform applyをし直したところpingにすべて成功するようになりましたので、terraform.tfvars.templateについても修正すべくPR作成しました。

お忙しい中恐縮ですがレビューいただけると幸いです。