### PR TITLE
fix: commands_summary.mdのコマンドを修正

### DIFF
--- a/commands_summary.md
+++ b/commands_summary.md
@@ -391,7 +391,7 @@ tiup playground scale-out --db 2
 リージョンIDとキー範囲を含む、Booksテーブルのリージョン情報を表示します。
 
 ```sql
-SELECT region_id,start_key, end_key, table_name, db_name FROM information_schema.tikv_region_status WHERE table_name = 'Books';
+SELECT region_id, start_key, end_key, table_name, db_name FROM information_schema.tikv_region_status WHERE table_name = 'Books';
 ```
 
 クラスター全体のすべてのリージョンリーダーをリストします。
@@ -403,7 +403,7 @@ SELECT * FROM information_schema.tikv_region_peers WHERE is_leader = 1 ORDER BY 
 IPアドレスとstore_idを含むすべてのTiKVストアの詳細なステータスを表示します。
 
 ```sql
-SELECT * FROM tikv_store_status;
+SELECT * FROM information_schema.tikv_store_status;
 ```
 
 information_schemaデータベースに切り替えます。


### PR DESCRIPTION
## 概要

いきなりPRすみません
こちらのリポジトリを参考に書籍を学習進めている者です。
（とても役立っております、ありがとうございます！）

commands_summary.md に記載されているコマンドが書籍で紹介されたコマンドと異なっており、実行した所エラーになったので、その修正のプルリクエストとなります。 

修正が不要であればクローズしていただいて問題ございません 🙏 

## やったこと

**1. TiKVノード情報を取得するコマンドを修正**

commands_summary.md に記載されているコマンドを実行するとエラーになります↓

書籍ではこのコマンドを実行した後の次のページで`USE information_schema` を実行するという流れなので、このコマンド時点ではスキーマ指定が必要そうです
（実際書籍の方でもP145 オレンジ塗り潰しのコマンド例の箇所も、`SELECT * FROM information_schema.tikv_store_status;`といった形でスキーマ指定のクエリとなっています。
ただその下の実行結果はスキーマ指定なしのクエリになっているので乖離しちゃってますが・・・）

<details><summary>修正前</summary>
<p>

```
mysql> SELECT * FROM tikv_store_status;
ERROR 1146 (42S02): Table 'library.tikv_store_status' doesn't exist
```

</p>
</details> 

<details><summary>修正後</summary>
<p>

```
mysql> SELECT * FROM information_schema.tikv_store_status;
+----------+-----------------+-------------+------------------+-------+---------+----------+-----------+--------------+---------------+--------------+-------------+--------------+---------------+--------------------+-------------+---------------------+---------------------+---------------+
| STORE_ID | ADDRESS         | STORE_STATE | STORE_STATE_NAME | LABEL | VERSION | CAPACITY | AVAILABLE | LEADER_COUNT | LEADER_WEIGHT | LEADER_SCORE | LEADER_SIZE | REGION_COUNT | REGION_WEIGHT | REGION_SCORE       | REGION_SIZE | START_TS            | LAST_HEARTBEAT_TS   | UPTIME        |
+----------+-----------------+-------------+------------------+-------+---------+----------+-----------+--------------+---------------+--------------+-------------+--------------+---------------+--------------------+-------------+---------------------+---------------------+---------------+
|        1 | 127.0.0.1:20160 |           0 | Up               | null  | 8.5.5   | 460.4GiB | 286.5GiB  |           29 |             1 |           29 |          29 |           67 |             1 | 117.93066205923976 |          67 | 2026-03-18 09:24:56 | 2026-03-18 09:43:37 | 18m41.15676s  |
|        5 | 127.0.0.1:20162 |           0 | Up               | null  | 8.5.5   | 460.4GiB | 286.5GiB  |           19 |             1 |           19 |          19 |           67 |             1 | 117.93066205923976 |          67 | 2026-03-18 09:24:56 | 2026-03-18 09:43:37 | 18m41.12141s  |
|        2 | 127.0.0.1:20161 |           0 | Up               | null  | 8.5.5   | 460.4GiB | 286.5GiB  |           19 |             1 |           19 |          19 |           67 |             1 | 117.93066205923976 |          67 | 2026-03-18 09:24:56 | 2026-03-18 09:43:37 | 18m41.075685s |
+----------+-----------------+-------------+------------------+-------+---------+----------+-----------+--------------+---------------+--------------+-------------+--------------+---------------+--------------------+-------------+---------------------+---------------------+---------------+
3 rows in set (0.00 sec)
```

</p>
</details> 

**2. SELECT句で指定するカラム間にスペースを追加**

1箇所だけスペースがない箇所があったので、ついでに修正させていただきました 🙇‍♂️ 